### PR TITLE
Allow overriding default font

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 </div>
 
-⚠️ **Charis SIL font is needed** for this package to work exactly as intended. If you don't already have this font installed, visit <https://software.sil.org/charis/download/>. New Computer Modern is used for arrows.
+⚠️ **Charis SIL font is needed** for this package to work exactly as intended out of the box. If you don't already have this font installed, visit <https://software.sil.org/charis/download/>. New Computer Modern is used for arrows, which is included with Typst by default.
 
 ## Some examples
 
@@ -76,7 +76,7 @@
       <img src="gallery/autoseg_example_1.png" width="250px">
     </a>
   </td>
-  
+
   <td>
       <a href="gallery/autoseg_example_3.typ">
       <img src="gallery/autoseg_example_3.png" width="250px">
@@ -104,7 +104,7 @@
       <img src="gallery/maxent_example.png" width="250px">
     </a>
   </td>
-  
+
 </tr>
 <tr>
   <td>SPE-style matrix</td>
@@ -187,7 +187,7 @@ For the most up-to-date information about the package, vignettes and demos, visi
 // With devoicing
 #ipa("\\r z")  // → z̥
 
-// Syllabic segments 
+// Syllabic segments
 #ipa("\\v n")  // → n̩
 
 // Affricates
@@ -299,7 +299,7 @@ Phonokit provides three functions for visualizing different levels of prosodic s
 #word("('ka.va.mi)")
 
 // Multiple feet, where foot = main foot is to the left
-#word("('ka.ta)('vas.lo)", foot: "L") 
+#word("('ka.ta)('vas.lo)", foot: "L")
 ```
 
 **Prosody notation:**

--- a/autosegmental.typ
+++ b/autosegmental.typ
@@ -14,6 +14,7 @@
   multilinks: (),
   baseline: 40%,
   gloss: "",
+  font: "Charis SIL",
 ) = {
   box(inset: 1.2em, baseline: baseline, cetz.canvas({
     import cetz.draw: *
@@ -45,7 +46,7 @@
         // 3. Labels (segment)
         // Use horizon alignment to ensure consistent baseline across all segments
         content((x, seg_y), padding: 0.1, anchor: seg_anchor_dir, box(height: 1em, align(horizon, text(
-          font: "Charis SIL",
+          font: font,
           ipa(seg),
         ))))
 
@@ -72,7 +73,7 @@
               radius: 100%,
               width: 1.2em,
               height: 1.2em,
-              align(center + horizon, text(font: "Charis SIL", f)),
+              align(center + horizon, text(font: font, f)),
             ))
 
             // Create anchor for this specific tone (for sub-indexing in links)
@@ -162,7 +163,7 @@
         radius: 100%,
         width: 1.2em,
         height: 1.2em,
-        align(center + horizon, text(font: "Charis SIL", tone_text)),
+        align(center + horizon, text(font: font, tone_text)),
       ))
 
       // Draw solid lines to each segment (no arrows, no dashes)

--- a/consonants.typ
+++ b/consonants.typ
@@ -271,6 +271,7 @@
   label-width: 3.5,
   label-height: 1.2,
   scale: 0.7,
+  font: "Charis SIL",
 ) = {
   // Determine which consonants to plot
   let consonants-to-plot = ""
@@ -673,13 +674,13 @@
         if pair.voiced != none {
           let pos = (cell-center-x, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiced), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiced), anchor: "center")
         }
         // In rare cases where voiceless sonorants exist, also center them
         if pair.voiceless != none {
           let pos = (cell-center-x, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiceless), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiceless), anchor: "center")
         }
       } else {
         // Obstruents: use left/right positioning for voicing contrast
@@ -688,13 +689,13 @@
         if pair.voiceless != none {
           let pos = (cell-center-x - offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiceless), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiceless), anchor: "center")
         }
 
         if pair.voiced != none {
           let pos = (cell-center-x + offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiced), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiced), anchor: "center")
         }
       }
     }
@@ -716,7 +717,7 @@
         if pair.voiceless != none {
           let pos = (cell-center-x - offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiceless), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiceless), anchor: "center")
         }
       }
     }
@@ -739,13 +740,13 @@
         if pair.voiceless != none {
           let pos = (cell-center-x - offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiceless), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiceless), anchor: "center")
         }
 
         if pair.voiced != none {
           let pos = (cell-center-x + offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiced), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiced), anchor: "center")
         }
       }
     }
@@ -768,7 +769,7 @@
         if pair.voiceless != none {
           let pos = (cell-center-x - offset, cell-center-y)
           circle(pos, radius: scaled-circle-radius, fill: white, stroke: none)
-          content(pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", pair.voiceless), anchor: "center")
+          content(pos, text(size: scaled-font-size * 1pt, font: font, pair.voiceless), anchor: "center")
         }
       }
     }

--- a/features.typ
+++ b/features.typ
@@ -20,7 +20,7 @@
 /// #feat("+consonantal", "-sonorant", "+voice")
 /// #feat("+cons,-son,+voice")  // comma-separated also works
 /// ```
-#let feat(..args) = {
+#let feat(..args, font: "Charis SIL") = {
   let items = args.pos()
 
   // 1. Split string if comma-separated
@@ -28,11 +28,11 @@
     items = items.at(0).split(",")
   }
 
-  // 2. Style the items (Charis SIL + Larger Size)
+  // 2. Style the items (Charis SIL by default + Larger Size)
   let features = items.map(i => {
     let content = if type(i) == str { i.trim() } else { i }
-    // Set font to Charis SIL and size to normal (1em) or larger (e.g., 1.1em)
-    text(font: "Charis SIL", size: 1em, content)
+    // Set font to Charis SIL by default and size to normal (1em) or larger (e.g., 1.1em)
+    text(font: font, size: 1em, content)
   })
 
   // 3. Use math.vec for perfect axis alignment
@@ -2101,10 +2101,10 @@
   }
 
   // Display as inline block with top alignment to allow side-by-side placement
-  let phoneme = text(size: 1em, font: "Charis SIL")[/#symbol/]
+  let phoneme = text(size: 1em, font: font)[/#symbol/]
 
   // Build matrix manually for precise control over alignment
-  let features = feature-list.map(f => text(font: "Charis SIL", size: 0.8em)[#f])
+  let features = feature-list.map(f => text(font: font, size: 0.8em)[#f])
   let content-stack = stack(
     dir: ttb,
     spacing: 0.55em,

--- a/grids.typ
+++ b/grids.typ
@@ -33,7 +33,7 @@
 //    met-grid(("te", 2), ("ne", 1), ("see", 3), ipa: true)  // Auto-converts strings to IPA
 //    Format: array of (content, level) tuples
 //
-#let met-grid(..args, ipa: true) = {
+#let met-grid(..args, ipa: true, font: "Charis SIL") = {
   let data = ()
 
   // Determine input format
@@ -49,7 +49,7 @@
 
         // If ipa mode is enabled and text-content is a string, convert it
         if ipa and type(text-content) == str {
-          text-content = text(font: "Charis SIL", ipa-to-unicode(text-content))
+          text-content = text(font: font, ipa-to-unicode(text-content))
         }
 
         data.push((text: text-content, level: level))

--- a/hasse.typ
+++ b/hasse.typ
@@ -54,6 +54,7 @@
   scale: auto,
   node-spacing: 2.5,
   level-spacing: 1.5,
+  font: "Charis SIL",
 ) = {
   // Validate input
   assert(type(rankings) == array, message: "rankings must be an array of tuples")
@@ -449,7 +450,7 @@
         padding: 0.1,
         anchor: "center",
         text(
-          font: "Charis SIL",
+          font: font,
           size: 10pt * scale-factor,
           formatted-name,
         ),

--- a/ipa.typ
+++ b/ipa.typ
@@ -237,7 +237,7 @@
   result
 }
 
-// Main IPA function: converts tipa-style notation to IPA with Charis SIL font
-#let ipa(input) = {
-  text(font: "Charis SIL", ipa-to-unicode(input))
+// Main IPA function: converts tipa-style notation to IPA with Charis SIL as default font
+#let ipa(input, font: "Charis SIL") = {
+  text(font: font, ipa-to-unicode(input))
 }

--- a/lib.typ
+++ b/lib.typ
@@ -39,8 +39,9 @@
 ///
 /// Arguments:
 /// - input (string): tipa-style notation
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
-/// Returns: IPA symbols in Charis SIL font
+/// Returns: IPA symbols in Charis SIL as default font
 #let ipa = ipa
 
 // Re-export Sonority function
@@ -61,6 +62,7 @@
 /// - scale (float): Overall scale factor for the diagram (default: 1.0)
 /// - y-range (array): Vertical axis range for plotting (default: (0, 8))
 /// - show-lines (bool): Connect phonemes with dashed lines (default: true)
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: CeTZ drawing of the sonority profile
 ///
@@ -159,6 +161,7 @@
 /// - String format: `met-grid("te2.ne1.see3.Ti3.tans1")`
 /// - Array with IPA: `met-grid(("te", 2), ("ne", 1), ("si", 3), ipa: true)`
 /// - ipa (bool): Automatically convert strings to IPA notation (default: true)
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: Table showing syllables with stacked × marks indicating stress levels
 ///
@@ -187,6 +190,7 @@
 /// - rows (int): Number of horizontal grid lines (default: 3)
 /// - cols (int): Number of vertical grid lines (default: 2)
 /// - scale (float): Scale factor for entire chart (default: 0.7)
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: CeTZ drawing of IPA vowel chart with positioned vowels
 ///
@@ -218,6 +222,7 @@
 /// - label-width (float): Width of row labels (default: 3.5)
 /// - label-height (float): Height of column labels (default: 1.2)
 /// - scale (float): Scale factor for entire table (default: 0.7)
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: CeTZ drawing of IPA consonant table with positioned consonants
 ///
@@ -432,6 +437,7 @@
 /// - scale (number or auto): Scale factor for diagram (default: auto-scales based on complexity)
 /// - node-spacing (number): Horizontal spacing between nodes (default: 2.5)
 /// - level-spacing (number): Vertical spacing between levels (default: 1.5)
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: A Hasse diagram showing the constraint hierarchy
 ///
@@ -460,6 +466,7 @@
 ///
 /// Arguments:
 /// - ..args: Features as separate arguments or comma-separated string
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: Mathematical vector notation with features
 ///
@@ -511,6 +518,7 @@
 /// - multilinks (array): Tuples of (feature-index, (seg1, seg2, ...)) for one-to-many links (default: ())
 /// - baseline (string): Optional baseline text below segments (default: "")
 /// - gloss (string): Optional gloss text below baseline (default: "")
+/// - font (string): Font name for rendering IPA (default: "Charis SIL")
 ///
 /// Returns: Autosegmental representation
 ///

--- a/sonority.typ
+++ b/sonority.typ
@@ -166,6 +166,7 @@
   scale: 1.0, // Overall scale
   y-range: (0, 8), // Sonority range for y-axis
   show-lines: true, // Connect phonemes with lines
+  font: "Charis SIL",
 ) = {
   // Convert tipa-style input to IPA
   let ipa-string = ipa-to-unicode(word)
@@ -233,7 +234,7 @@
       // Add phoneme label (always black now)
       content(
         (x, y),
-        text(size: 10pt, font: "Charis SIL", fill: black)[#phoneme],
+        text(size: 10pt, font: font, fill: black)[#phoneme],
         anchor: "center",
       )
     }

--- a/vowels.typ
+++ b/vowels.typ
@@ -123,6 +123,7 @@
   rows: 3, // Only 2 internal horizontal lines
   cols: 2, // Only 1 vertical line inside trapezoid
   scale: 0.7, // Scale factor for entire chart
+  font: "Charis SIL",
 ) = {
   // Determine which vowels to plot
   let vowels-to-plot = ""
@@ -235,7 +236,7 @@
       // Draw white circle to cover grid lines
       circle(vp.pos, radius: scaled-circle-radius, fill: white, stroke: none)
       // Draw vowel on top
-      content(vp.pos, text(size: scaled-font-size * 1pt, font: "Charis SIL", vp.vowel))
+      content(vp.pos, text(size: scaled-font-size * 1pt, font: font, vp.vowel))
     }
   })
 }


### PR DESCRIPTION
This PR introduces a `font` parameter to every function that previously exclusively used Charis SIL. Charis SIL remains the default for these parameters, making this change fully backwards compatible.

# Background

Despite the popularity of Charis SIL, there are many fonts with good support for IPA transcriptions, such as Libertinus Serif or New Computer Modern (built into Typst), other SIL fonts such as Doulos SIL, Brill, Noto Fonts, DejaVu fonts, and plenty of others. Exclusively using Charis SIL within phonokit can cause the fonts in a document be inconsistent.

This change allows the font to be changed, allowing this consistency in documents.
